### PR TITLE
Added index file reference in Info.plist

### DIFF
--- a/Contents/Info.plist
+++ b/Contents/Info.plist
@@ -10,5 +10,7 @@
 	<string>Markdown</string>
 	<key>isDashDocset</key>
 	<true/>
+	<key>dashIndexFilePath</key>
+	<string>syntax.html</string>
 </dict>
 </plist>


### PR DESCRIPTION
Dash was complaining about a missing index file so I added this entry to the Info.plist file. Now the documentation itself is used as the index file.
